### PR TITLE
Add travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+
+matrix:
+  allow_failures:
+    - python: "3.2"
+    - python: "3.3"
+
 # command to install dependencies
 #install:
 #  - "pip install . --use-mirrors"


### PR DESCRIPTION
See http://about.travis-ci.org/docs/user/getting-started/

Automated testing across different python versions, I've set python 3.2 and 3.3 to be allowable failures (since they both fail), allows you to see whether a pull requests passes your tests without downloading and running them yourself.
