### PR TITLE
Adding a seed to faker to provide for repeatable data sequences

### DIFF
--- a/faker/__init__.py
+++ b/faker/__init__.py
@@ -28,13 +28,19 @@ def uses_names(func):
 
 class Faker(object):
 
-    def __init__(self):
+    def __init__(self, seed=None):
         self._names = None
         self._name_accesses = set()
+        if seed is not None and type(seed) is int:
+            random.seed(seed)
 
     def _get_names(self):
         self._names = [rand(data.FIRST_NAMES), rand(data.LAST_NAMES)]
         self._name_accesses = set()
+
+    def reset(self, seed=None):
+        if seed is not None and type(seed) is int:
+            random.seed(seed)
 
     @uses_names
     def name(self):

--- a/faker/__init__.py
+++ b/faker/__init__.py
@@ -28,10 +28,22 @@ def uses_names(func):
 
 class Faker(object):
 
-    def __init__(self, seed=None):
+    def __init__(self,
+        seed=None, zip_type=None, min_age=None, max_age=None):
+
         self._names = None
         self._name_accesses = set()
-        # if set the random seed
+
+        # set the type of zip to None (default), 5 or 9
+        self.zip_type = zip_type if zip_type in [None, 5, 9] else None
+
+        # set the minimum and maximum ages (swap if min > max)
+        self.min_age = min_age if type(min_age) == int else 16
+        self.max_age = max_age if type(max_age) == int else 80
+        if self.min_age > self.max_age:
+            self.min_age, self.max_age = self.max_age, self.min_age
+
+        # set the random seed
         self.reset(seed)
 
     def _get_names(self):
@@ -40,11 +52,11 @@ class Faker(object):
 
     def reset(self, seed=None):
         """Reset the seed for the random number generator.
-        
+
         The seed can be any integer and using the same
         seed repeatedly will generate the same sequence
         of random numbers multiple times. If no seed (or
-        an invalid seed) is given, the seed will be a 
+        an invalid seed) is given, the seed will be a
         new randomized value.
         """
         if seed is not None and type(seed) is int:
@@ -82,19 +94,22 @@ class Faker(object):
 
     def street_address(self):
         return numerify(random.choice(["##### %s" % patterns.STREET_NAME(),
-                                         "#### %s Ave." % patterns.STREET_NAME(),
-                                         "### %s St." % patterns.STREET_NAME(),
-                                         "### %s %s" % (patterns.STREET_NAME(), secondary_address()),
-                                         "#### %s %s" % (patterns.STREET_NAME(), secondary_address())]))
+                                       "#### %s Ave." % patterns.STREET_NAME(),
+                                       "### %s St." % patterns.STREET_NAME(),
+                                       "### %s %s" % (patterns.STREET_NAME(), secondary_address()),
+                                       "#### %s %s" % (patterns.STREET_NAME(), secondary_address())]))
 
     def city(self):
-        return patterns.CITY()
+         return patterns.CITY()
 
     def state(self):
         return rand(data.STATE_ABBR)
 
     def zip_code(self):
-        return numerify(random.choice(["#####", "#####-####"]))
+        zips = { None:random.choice(["#####", "#####-####"]),
+                 5:"#####",
+                 9:"#####-####" }
+        return numerify(zips[self.zip_type])
 
     def company(self):
         return patterns.COMPANY_NAME()
@@ -108,7 +123,7 @@ class Faker(object):
         return " ".join(paragraph)
 
     def age(self):
-        return random.randint(16, 80)
+        return random.randint(self.min_age, self.max_age)
 
     def gender(self):
         return random.choice(["M","F"])

--- a/faker/__init__.py
+++ b/faker/__init__.py
@@ -31,16 +31,26 @@ class Faker(object):
     def __init__(self, seed=None):
         self._names = None
         self._name_accesses = set()
-        if seed is not None and type(seed) is int:
-            random.seed(seed)
+        # if set the random seed
+        self.reset(seed)
 
     def _get_names(self):
         self._names = [rand(data.FIRST_NAMES), rand(data.LAST_NAMES)]
         self._name_accesses = set()
 
     def reset(self, seed=None):
+        """Reset the seed for the random number generator.
+        
+        The seed can be any integer and using the same
+        seed repeatedly will generate the same sequence
+        of random numbers multiple times. If no seed (or
+        an invalid seed) is given, the seed will be a 
+        new randomized value.
+        """
         if seed is not None and type(seed) is int:
             random.seed(seed)
+        else:
+            random.seed()
 
     @uses_names
     def name(self):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -94,20 +94,57 @@ def test_name_correspondance2():
     ok_(f1 in n1)
     ok_(f2 in n2)
 
-
 def test_age():
     f = Faker()
     age1 = f.age()
     age2 = f.age()
     ok_(isinstance(age1, int))
     ok_(isinstance(age2, int))
+    ok_(age1 >= f.min_age)
+    ok_(age1 <= f.max_age)
+    f = Faker(min_age=30, max_age=30)
+    age1 = f.age()
+    age2 = f.age()
+    ok_(age1 == age2)
+
+
+
+def test_zipcode():
+
+    f = Faker()
+    for zip in [f.zip_code() for i in range(50)]:
+        ok_(type(zip) is str)
+        ok_(len(zip) == 5 or len(zip) == 10)
+        if len(zip) == 5:
+            ok_(zip.isdigit())
+        else:
+            ok_(zip[:5].isdigit())
+            ok_(zip[6:].isdigit())
+            ok_(zip[5:6] == "-")
+
+    f = Faker(zip_type=5)
+    for zip in [f.zip_code() for i in range(50)]:
+        ok_(type(zip) is str)
+        ok_(len(zip) == 5)
+        ok_(zip.isdigit())
+
+    f = Faker(zip_type=9)
+    for zip in [f.zip_code() for i in range(50)]:
+        ok_(type(zip) is str)
+        ok_(len(zip) == 10)
+        ok_(zip[:5].isdigit())
+        ok_(zip[6:].isdigit())
+        ok_(zip[5:6] == "-")
 
 def test_seed():
+
+    # different initial names for python v2 vs. v3
     import sys
-    if sys.version_info.major == 2:
+    if str(sys.version_info[0]) == "2":
         initname = "Vita Kertzmann"
-    elif sys.version_info.major == 3:
+    elif str(sys.version_info[0]) == "3":
         initname = "Layla Cassin"
+
     f = Faker(1234)
     name1 = f.name()
     name2 = f.name()
@@ -116,6 +153,3 @@ def test_seed():
     f.reset(1234)
     name2 = f.name()
     ok_(name1 == name2)
-    
-
-    

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -101,3 +101,16 @@ def test_age():
     age2 = f.age()
     ok_(isinstance(age1, int))
     ok_(isinstance(age2, int))
+
+def test_seed():
+    f = Faker(1234)
+    name1 = f.name()
+    name2 = f.name()
+    ok_(name1 == "Vita Kertzmann")
+    ok_(name1 != name2)
+    f.reset(1234)
+    name2 = f.name()
+    ok_(name1 == name2)
+    
+
+    

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -103,10 +103,15 @@ def test_age():
     ok_(isinstance(age2, int))
 
 def test_seed():
+    import sys
+    if sys.version_info.major == 2:
+        initname = "Vita Kertzmann"
+    elif sys.version_info.major == 3:
+        initname = "Layla Cassin"
     f = Faker(1234)
     name1 = f.name()
     name2 = f.name()
-    ok_(name1 == "Vita Kertzmann")
+    ok_(name1 == initname)
     ok_(name1 != name2)
     f.reset(1234)
     name2 = f.name()


### PR DESCRIPTION
### Introduction

Faker has proved quite useful to my python testing library but I find that I need to be able to replicate the test sequences.  Fortunately it is based on the python random library and all random requires to reproduce its random sequences exactly is to use the same "seed" value each time.  

### faker/__init__.py

I added a new method to the class, `Faker.reset(self, seed)`, which reseeds the random number generator if the seed value is an integer (for anything else including `None`, it resets the generator with a random value based on time of day).  I also modified `Faker.__init__(self, seed)` to take an optional seed and call the `.reset()` method with it (or with `None`). 

### tests/test_api.py

There is a new test, `test_seed()`, which tests resetting the seed.

### Comments

A call to random.seed(<int>) with an integer argument is sufficient to reset the random number generator.  If you call the seed again with the same exact value, all subsequent random calls will be reproduced identically. EVERY single call must be exact, and in the same order and with the same arguments.  Since faker calls the random number generator on most method calls, the sequence of faker calls must also be the same.  Changing even one of them will create a new order.

For instance:

``` python
    >>> import faker # with new changes
    >>> f = faker.Faker(1234)
    >>> f.name()
    u'Vita Kertzmann'
    >>> f.city()
    u'Feiltown'
    >>> f.state()
    u'LA'
    >>> f .seed(1234)
    >>> f.name()
    u'Vita Kertzmann'
    >>> f.state()
    u'AL'
    >>> f.city()
    u'New Art'
```
Enjoy!

